### PR TITLE
buildmodernize: define g_client_translations=nullptr in a client TU

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -391,7 +391,10 @@ add_subdirectory(server)
 # a compiler error and you need to instead add it to client_SRCS or common_SRCS.
 set(independent_SRCS
 	chat.cpp
+	content_nodemeta.cpp
 	convert_json.cpp
+	craftdef.cpp
+	debug.cpp
 	face_position_cache.cpp
 	gettext_plural_form.cpp
 	httpfetch.cpp
@@ -411,11 +414,17 @@ set(independent_SRCS
 	particles.cpp
 	profiler.cpp
 	serialization.cpp
+	settings.cpp
 	staticobject.cpp
 	terminal_chat_console.cpp
 	texture_override.cpp
 	tileanimation.cpp
+	tool.cpp
+	${common_network_SRCS}
+	${content_SRCS}
+	${database_SRCS}
 	${threading_SRCS}
+	${util_SRCS}
 )
 
 # /!\ Consider carefully before adding files here /!\
@@ -423,9 +432,6 @@ set(common_SRCS
 	clientdynamicinfo.cpp
 	collision.cpp
 	content_mapnode.cpp
-	content_nodemeta.cpp
-	craftdef.cpp
-	debug.cpp
 	defaultsettings.cpp
 	emerge.cpp
 	environment.cpp
@@ -451,19 +457,14 @@ set(common_SRCS
 	server.cpp
 	serverenvironment.cpp
 	servermap.cpp
-	settings.cpp
-	tool.cpp
 	translation.cpp
 	version.cpp
 	voxel.cpp
 	voxelalgorithms.cpp
-	${common_network_SRCS}
 	${common_SCRIPT_SRCS}
 	${common_server_SRCS}
-	${content_SRCS}
-	${database_SRCS}
 	${mapgen_SRCS}
-	${UTIL_SRCS}
+	${server_network_SRCS}
 )
 
 if(ANDROID)
@@ -587,6 +588,9 @@ add_library(EngineCommon OBJECT
 	${independent_SRCS}
 )
 add_dependencies(EngineCommon GenerateVersion)
+target_link_libraries(EngineCommon
+	sha256
+)
 get_target_property(
 	IRRLICHT_INCLUDES IrrlichtMt::IrrlichtMt INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(EngineCommon PRIVATE ${IRRLICHT_INCLUDES})

--- a/src/content/subgames.cpp
+++ b/src/content/subgames.cpp
@@ -28,10 +28,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "map_settings_manager.h"
 #include "util/string.h"
 
-#if CHECK_CLIENT_BUILD()
-#include "client/texturepaths.h"
-#endif
-
 // The maximum number of identical world names allowed
 #define MAX_WORLD_NAMES 100
 
@@ -96,8 +92,7 @@ std::string getSubgamePathEnv()
 
 static SubgameSpec getSubgameSpec(const std::string &game_id,
 		const std::string &game_path,
-		const std::unordered_map<std::string, std::string> &mods_paths,
-		const std::string &menuicon_path)
+		const std::unordered_map<std::string, std::string> &mods_paths)
 {
 	const auto gamemods_path = game_path + DIR_DELIM + "mods";
 	// Get meta
@@ -130,7 +125,7 @@ static SubgameSpec getSubgameSpec(const std::string &game_id,
 		last_mod = conf.get("last_mod");
 
 	SubgameSpec spec(game_id, game_path, gamemods_path, mods_paths, game_title,
-			menuicon_path, game_author, game_release, first_mod, last_mod);
+			game_author, game_release, first_mod, last_mod);
 
 	if (conf.exists("name") && !conf.exists("title"))
 		spec.deprecation_msgs.push_back("\"name\" setting in game.conf is deprecated, please use \"title\" instead");
@@ -191,13 +186,7 @@ SubgameSpec findSubgame(const std::string &id)
 		mods_paths[fs::AbsolutePath(mod_path)] = mod_path;
 	}
 
-	std::string menuicon_path;
-#if CHECK_CLIENT_BUILD()
-	menuicon_path = getImagePath(
-			game_path + DIR_DELIM + "menu" + DIR_DELIM + "icon.png");
-#endif
-
-	return getSubgameSpec(id, game_path, mods_paths, menuicon_path);
+	return getSubgameSpec(id, game_path, mods_paths);
 }
 
 SubgameSpec findWorldSubgame(const std::string &world_path)
@@ -206,7 +195,7 @@ SubgameSpec findWorldSubgame(const std::string &world_path)
 	// See if world contains an embedded game; if so, use it.
 	std::string world_gamepath = world_path + DIR_DELIM + "game";
 	if (fs::PathExists(world_gamepath))
-		return getSubgameSpec(world_gameid, world_gamepath, {}, "");
+		return getSubgameSpec(world_gameid, world_gamepath, {});
 	return findSubgame(world_gameid);
 }
 

--- a/src/content/subgames.h
+++ b/src/content/subgames.h
@@ -41,7 +41,6 @@ struct SubgameSpec
 	 * Map from virtual path to mods path
 	 */
 	std::unordered_map<std::string, std::string> addon_mods_paths;
-	std::string menuicon_path;
 
 	// For logging purposes
 	std::vector<const char *> deprecation_msgs;
@@ -50,7 +49,6 @@ struct SubgameSpec
 			const std::string &gamemods_path = "",
 			const std::unordered_map<std::string, std::string> &addon_mods_paths = {},
 			const std::string &title = "",
-			const std::string &menuicon_path = "",
 			const std::string &author = "", int release = 0,
 			const std::string &first_mod = "",
 			const std::string &last_mod = "") :
@@ -60,8 +58,7 @@ struct SubgameSpec
 			last_mod(last_mod),
 			path(path),
 			gamemods_path(gamemods_path),
-			addon_mods_paths(addon_mods_paths),
-			menuicon_path(menuicon_path)
+			addon_mods_paths(addon_mods_paths)
 	{
 	}
 

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -5,9 +5,13 @@ set(common_network_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/mtp/threads.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/networkpacket.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/networkprotocol.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/socket.cpp
+	PARENT_SCOPE
+)
+
+set(server_network_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/serveropcodes.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/serverpackethandler.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/socket.cpp
 	PARENT_SCOPE
 )
 

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -31,7 +31,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <tuple>
 
 
-bool is_valid_player_name(std::string_view name) {
+bool is_valid_player_name(std::string_view name)
+{
 	return !name.empty() && name.size() <= PLAYERNAME_SIZE && string_allowed(name, PLAYERNAME_ALLOWED_CHARS);
 }
 
@@ -209,8 +210,6 @@ void PlayerControl::setMovementFromKeys()
 		movement_direction = std::atan2(x, y);
 }
 
-#if CHECK_CLIENT_BUILD()
-
 u32 PlayerControl::getKeysPressed() const
 {
 	u32 keypress_bits =
@@ -254,7 +253,6 @@ u32 PlayerControl::getKeysPressed() const
 	return keypress_bits;
 }
 
-#endif
 
 void PlayerControl::unpackKeysPressed(u32 keypress_bits)
 {

--- a/src/player.h
+++ b/src/player.h
@@ -91,11 +91,9 @@ struct PlayerControl
 	// joystick input.
 	void setMovementFromKeys();
 
-#if CHECK_CLIENT_BUILD()
 	// For client use
 	u32 getKeysPressed() const;
 	inline bool isMoving() const { return movement_speed > 0.001f; }
-#endif
 
 	// For server use
 	void unpackKeysPressed(u32 keypress_bits);

--- a/src/script/lua_api/l_mainmenu.cpp
+++ b/src/script/lua_api/l_mainmenu.cpp
@@ -37,6 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "clientdynamicinfo.h"
 #include "client/client.h"
 #include "client/renderingengine.h"
+#include "client/texturepaths.h"
 #include "network/networkprotocol.h"
 #include "content/mod_configuration.h"
 #include "threading/mutex_auto_lock.h"
@@ -330,8 +331,9 @@ int ModApiMainMenu::l_get_games(lua_State *L)
 		lua_pushinteger(L, game.release);
 		lua_settable(L,    top_lvl2);
 
+		auto menuicon = getImagePath(game.path + DIR_DELIM "menu" DIR_DELIM "icon.png");
 		lua_pushstring(L,  "menuicon_path");
-		lua_pushstring(L,  game.menuicon_path.c_str());
+		lua_pushstring(L,  menuicon.c_str());
 		lua_settable(L,    top_lvl2);
 
 		lua_pushstring(L, "addon_mods_paths");

--- a/src/translation.cpp
+++ b/src/translation.cpp
@@ -29,6 +29,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 // Client translations
 static Translations client_translations;
 Translations *g_client_translations = &client_translations;
+#else
+Translations *g_client_translations = nullptr;
 #endif
 
 const std::string_view Translations::getFileLanguage(const std::string &filename)

--- a/src/translation.h
+++ b/src/translation.h
@@ -28,9 +28,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "config.h"
 
 class Translations;
-#if IS_CLIENT_BUILD
 extern Translations *g_client_translations;
-#endif
 
 class Translations
 {

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(UTIL_SRCS
+set(util_SRCS
 	${CMAKE_CURRENT_SOURCE_DIR}/areastore.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/auth.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/colorize.cpp

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -932,16 +932,6 @@ std::wstring translate_string(std::wstring_view s, Translations *translations)
 	return res;
 }
 
-// Translate string client side
-std::wstring translate_string(std::wstring_view s)
-{
-#if !CHECK_CLIENT_BUILD()
-	return translate_string(s, nullptr);
-#else
-	return translate_string(s, g_client_translations);
-#endif
-}
-
 static const std::array<std::wstring_view, 30> disallowed_dir_names = {
 	// Problematic filenames from here:
 	// https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#file-and-directory-names

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -23,6 +23,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "config.h" // IS_CLIENT_BUILD
 #if IS_CLIENT_BUILD
 #include "irrString.h"
+#include "translation.h"
 #endif
 #include <cstdlib>
 #include <string>
@@ -656,9 +657,17 @@ std::vector<std::basic_string<T> > split(const std::basic_string<T> &s, T delim)
 
 std::wstring translate_string(std::wstring_view s, Translations *translations);
 
-std::wstring translate_string(std::wstring_view s);
+inline std::wstring translate_string(std::wstring_view s)
+{
+#if IS_CLIENT_BUILD
+	return translate_string(s, g_client_translations);
+#else
+	return translate_string(s, nullptr);
+#endif
+}
 
-inline std::wstring unescape_translate(std::wstring_view s) {
+inline std::wstring unescape_translate(std::wstring_view s)
+{
 	return unescape_enriched(translate_string(s));
 }
 

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -23,8 +23,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include "config.h" // IS_CLIENT_BUILD
 #if IS_CLIENT_BUILD
 #include "irrString.h"
-#include "translation.h"
 #endif
+#include "translation.h"
 #include <cstdlib>
 #include <string>
 #include <string_view>
@@ -659,11 +659,7 @@ std::wstring translate_string(std::wstring_view s, Translations *translations);
 
 inline std::wstring translate_string(std::wstring_view s)
 {
-#if IS_CLIENT_BUILD
 	return translate_string(s, g_client_translations);
-#else
-	return translate_string(s, nullptr);
-#endif
 }
 
 inline std::wstring unescape_translate(std::wstring_view s)


### PR DESCRIPTION
As suggested in <https://github.com/minetest/minetest/pull/15126#discussion_r1793258585>.
This would make `translate_string` have the same behaviour as in master, even in independent srcs.